### PR TITLE
store advanced search configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ There are default settings configured in the `nerm_config.yaml` file (in the .ne
 - [ ] Advanced Searching
     - [x] See all saved Searches (list)
     - [x] Run saved search (run)
+    - [ ] Store Search via GET
     - [ ] Create/Run Search via file (-f)
     - [ ] Create Search via prompts (-c)
         - Utility for getting all stored attributes

--- a/cmd/advanced_search/advanced_search.go
+++ b/cmd/advanced_search/advanced_search.go
@@ -86,6 +86,7 @@ func NewAdvancedSearchCommand() *cobra.Command {
 		newAdvancedSearchShowCommand(),
 		newAdvancedSearchRunCommand(),
 		newAdvancedSearchCreateCommand(),
+		newAdvancedSearchStoreCommand(),
 	)
 
 	return cmd
@@ -117,6 +118,22 @@ func printCountTable(data [][]string) {
 	}
 
 	tbl.Print()
+}
+
+func storeAdvancedSearchJsonFile(fileLoc string, jsonData AdvancedSearchConfig) {
+
+	file, _ := os.OpenFile(fileLoc, os.O_APPEND|os.O_CREATE, os.ModePerm)
+	defer file.Close()
+	encoder := json.NewEncoder(file)
+
+	for i, rec := range jsonData.AdvancedSearch {
+		encoder.Encode(rec)
+		// if !lastLoop {
+		// 	file.WriteString(strings.Trim(",", "\""))
+		if (i + 1) != len(jsonData.AdvancedSearch) {
+			file.WriteString(strings.Trim(",", "\""))
+		}
+	}
 }
 
 func createAdvancedSearchJsonFile(fileLoc string) {

--- a/cmd/advanced_search/store.go
+++ b/cmd/advanced_search/store.go
@@ -1,0 +1,49 @@
+/*
+Copyright © 2024 Zachary Tarantino-Woolson <zachary.tarantino@sailpoint.com>
+*/
+package advanced_search
+
+import (
+	"encoding/json"
+	"fmt"
+	"nerm/cmd/configs"
+	"nerm/cmd/utilities"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func newAdvancedSearchStoreCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "store",
+		Short:   "Store the configuration of a an Advanced Search",
+		Long:    "Store the configuration of a an Advanced Search",
+		Example: "nerm advsearch store --id 1234",
+		Aliases: []string{"s"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := cmd.Flags().Lookup("id").Value.String()
+			var adv_searches AdvancedSearchConfig
+
+			params := url.Values{}
+			params.Add("id", id)
+
+			resp, requestErr := utilities.MakeAPIRequests("get", "advanced_search", "", params.Encode(), nil)
+			utilities.CheckError(requestErr)
+			err := json.Unmarshal(resp, &adv_searches)
+			utilities.CheckError(err)
+
+			outputLoc := configs.GetOutputFolder() + configs.GetCurrentEnvironment() + "_" + adv_searches.AdvancedSearch[0].Label + "_AdvancedSearch_Config" + strconv.Itoa(int(time.Now().Unix()))
+			storeAdvancedSearchJsonFile(outputLoc+".json", adv_searches)
+
+			fmt.Println("\n" + "Advanced Saerch config data stored in " + outputLoc)
+
+			return nil
+		},
+	}
+	cmd.Flags().StringP("id", "i", "", "ID of a specific Advanced Search")
+	cmd.MarkFlagRequired("id")
+
+	return cmd
+}


### PR DESCRIPTION
new command to store an advanced search config to a json file. This can then be modified to be run, reuploaded, etc.